### PR TITLE
feat: add imageUrl and productUrl optional fields to OrderItem interface

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -174,6 +174,8 @@ export interface OrderItem {
   price: ProductBusPrice;
   name?: string;
   note?: string;
+  imageUrl?: string;
+  productUrl?: string;
   shippingDimensions?: ShippingDimensions;
   custom?: Record<string, unknown>;
 }


### PR DESCRIPTION
Mirrors the schema change in helix-commerce-api. Both fields are optional strings so existing code that constructs OrderItem objects is unaffected.
