### PR TITLE
feat: add `taxCode` and `taxData` fields to `ProductBusEntry`

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -125,6 +125,16 @@ export interface ProductBusEntry {
    */
   custom?: Record<string, unknown>;
 
+  /**
+   * Tax classification code for this product.
+   */
+  taxCode?: string;
+
+  /**
+   * Free-form map of supplementary tax data
+   */
+  taxData?: Record<string, unknown>;
+
   // below are properties that are used to generate indices, not belonging to JSON-LD
 
   /**

--- a/test/StorageClient.test.js
+++ b/test/StorageClient.test.js
@@ -982,4 +982,57 @@ describe('StorageClient', () => {
       });
     });
   });
+
+  describe('ProductBusEntry tax fields', () => {
+    it('preserves taxCode through a save/fetch round-trip', async () => {
+      const ctx = CONTEXT();
+      const client = new StorageClient(ctx);
+      const product = {
+        sku: 'TAX-001',
+        name: 'Taxable Product',
+        taxCode: 'P0000000',
+      };
+
+      await client.saveProduct('org/site/store/view', 'TAX-001', product);
+      const result = await client.fetchProduct('org/site/store/view', 'TAX-001');
+      assert.strictEqual(result.taxCode, 'P0000000');
+    });
+
+    it('preserves taxData through a save/fetch round-trip', async () => {
+      const ctx = CONTEXT();
+      const client = new StorageClient(ctx);
+      const product = {
+        sku: 'TAX-002',
+        name: 'Taxable Product with Data',
+        taxData: { UDF10: 'FOOD', UDF11: 'OTHER', rate: 0.08 },
+      };
+
+      await client.saveProduct('org/site/store/view', 'TAX-002', product);
+      const result = await client.fetchProduct('org/site/store/view', 'TAX-002');
+      assert.deepStrictEqual(result.taxData, { UDF10: 'FOOD', UDF11: 'OTHER', rate: 0.08 });
+    });
+
+    it('fetches a product without taxCode or taxData (backwards compatibility)', async () => {
+      const ctx = CONTEXT();
+      const client = new StorageClient(ctx);
+      const product = { sku: 'TAX-003', name: 'Plain Product' };
+
+      await client.saveProduct('org/site/store/view', 'TAX-003', product);
+      const result = await client.fetchProduct('org/site/store/view', 'TAX-003');
+      assert.strictEqual(result.taxCode, undefined);
+      assert.strictEqual(result.taxData, undefined);
+    });
+
+    it('ProductBusVariant fixture does not include taxCode or taxData', () => {
+      const variant = {
+        sku: 'VAR-001',
+        name: 'Variant',
+        url: '/products/test/var-001',
+        images: [],
+        availability: 'https://schema.org/InStock',
+      };
+      assert.ok(!('taxCode' in variant));
+      assert.ok(!('taxData' in variant));
+    });
+  });
 });


### PR DESCRIPTION
Adds two optional fields to the `ProductBusEntry` schema for tax classification. `taxCode` is the product's tax category code, sent to real-time tax providers (e.g. Avalara AvaTax) as the item classification identifier to determine the correct tax rate. `taxData` is a free-form map for provider-specific supplementary fields (e.g. Avalara UDF10/UDF11). Both fields are optional and backwards-compatible — products without them are unaffected. `ProductBusVariant` is unchanged; tax classification is product-level, not variant-level.

