### PR TITLE
feat: optional `taxCode` and `taxData` on `BundleItemSimple` and `BundleItemVariant`

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -96,21 +96,35 @@ export interface BundleItemVariantOption {
  * One variant of a configurable bundle item. The server picks the variant
  * whose `options` are all satisfied by the parent line item's `selectedOptions`;
  * zero or multiple matches reject the preview.
+ *
+ * `taxCode` and `taxData` are optional per-variant overrides of the bundle
+ * parent's tax classification. When present, the Commerce API uses them for
+ * the variant's line in the tax-provider projection; when absent, the
+ * projection falls back to the bundle parent's `taxCode` / `taxData`.
  */
 export interface BundleItemVariant {
   sku: string;
   name?: string;
   price: BundleItemPrice;
   options: BundleItemVariantOption[];
+  taxCode?: string;
+  taxData?: Record<string, unknown>;
 }
 
 /**
  * Simple bundle item — a single SKU regardless of the parent's options.
+ *
+ * `taxCode` and `taxData` are optional per-component overrides of the bundle
+ * parent's tax classification. When present, the Commerce API uses them for
+ * the component's line in the tax-provider projection; when absent, the
+ * projection falls back to the bundle parent's `taxCode` / `taxData`.
  */
 export interface BundleItemSimple {
   sku: string;
   name: string;
   price: BundleItemPrice;
+  taxCode?: string;
+  taxData?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
The helix-commerce-api projection now reads each bundle component's own tax classification when present, falling back to the parent product's classification when absent. Bundle items published from catalog sync carry per-component `taxCode` and `taxData` derived from each Magento child's `tax_service_segment`.

Add both fields as optional to `BundleItemSimple` and `BundleItemVariant` with JSDoc explaining the per-component-overrides- parent semantics. The base `BundleItem` union type picks them up automatically via `BundleItemSimple`. Backwards-compatible — type shape additions only, no breaking changes.

