### PR TITLE
feat(types): add address validation state

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -264,6 +264,7 @@ export interface OrderAddress {
   company?: string;
   phone?: string;
   isDefault?: boolean;
+  isValidated?: boolean;
 }
 
 export interface OrderCustomer {


### PR DESCRIPTION
Expose an optional isValidated flag on shared order addresses so consumers can type persisted address verification state consistently without coupling the shared package to a validation provider.