### PR TITLE
feat(types): add customer timezone to orders

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -322,6 +322,8 @@ export interface Order {
   estimateToken?: string;
   /** Optional gift message to include with the order. Max 250 characters. */
   giftMessage?: string;
+  /** IANA timezone captured from the shopper's browser at checkout. */
+  customerTimezone?: string;
   /** Customer-defined key/value pairs for linking the order to external systems. */
   custom?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

Adds customerTimezone to the public Order type so checkout clients and the Commerce API have a shared contract for storing the shopper's browser timezone. The field is optional because existing orders and non-browser order creation paths may not provide it.