### PR TITLE
fix(types): sync public types (helix-commerce-api#435)

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -314,8 +314,6 @@ export interface ProductBusEntry {
   options?: ProductBusOption[];
   /** Aggregate customer rating for schema.org structured data. */
   aggregateRating?: SchemaOrgAggregateRating;
-  /** Freeform product specifications (HTML or plain text). */
-  specifications?: string;
   /** Product images. */
   images?: ProductBusMedia[];
   /** Available variants for a configurable product. */


### PR DESCRIPTION
Automated sync from helix-commerce-api PR #435:
https://github.com/adobe-rnd/helix-commerce-api/pull/435

Updates the generated TypeScript types in `src/types/public.d.ts` from the
runtime schemas in that PR.

Next steps (manual for now):
1. Merge and release this PR to publish a new `@dylandepass/helix-product-shared` version.
2. Bump that version in the source commerce-api PR so its type check passes.
3. Merge the commerce-api PR.

Opened by the **Sync public types** workflow. Closing the source PR closes this one.