### PR TITLE
fix(types): sync public types (helix-commerce-api#481)

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -257,10 +257,14 @@ export interface ProductBusVariant {
   images: ProductBusMedia[];
   /** Global Trade Item Number (barcode). */
   gtin?: string;
+  /** Manufacturer Part Number. Used as a product identifier when no GTIN is available. */
+  mpn?: string;
   /** Variant-specific description. */
   description?: string;
   /** schema.org availability status for a product or offer. */
   availability?: SchemaOrgAvailability;
+  /** ISO 8601 date when the variant becomes available. */
+  availabilityDate?: string;
   /** Option values that identify this variant (e.g. color=Red, size=Large). */
   options?: ProductBusOptionValue[];
   /** schema.org item condition. */
@@ -294,6 +298,12 @@ export interface ProductBusEntry {
   metaDescription?: string;
   /** Global Trade Item Number (barcode). */
   gtin?: string;
+  /** Manufacturer Part Number. Used as a product identifier when no GTIN is available. */
+  mpn?: string;
+  /** Merchant-defined product category, e.g. "Home > Kitchen > Blenders". */
+  productType?: string;
+  /** Google product taxonomy category, as a numeric taxonomy ID or full category path. */
+  googleProductCategory?: string;
   /** Canonical absolute URL for the product. */
   url?: string;
   /** Brand or manufacturer name. */


### PR DESCRIPTION
Automated sync from helix-commerce-api PR #481:
https://github.com/adobe-rnd/helix-commerce-api/pull/481

Updates the generated TypeScript types in `src/types/public.d.ts` from the
runtime schemas in that PR.

Next steps (manual for now):
1. Merge and release this PR to publish a new `@dylandepass/helix-product-shared` version.
2. Bump that version in the source commerce-api PR so its type check passes.
3. Merge the commerce-api PR.

Opened by the **Sync public types** workflow. Closing the source PR closes this one.