### PR TITLE
feat(cache): add product path variants

### DIFF
--- a/src/cache.d.ts
+++ b/src/cache.d.ts
@@ -24,6 +24,13 @@ export function computeProductPathKey(
 ): Promise<string>;
 
 /**
+ * Return the cacheable URL path variants for a Commerce product.
+ * @param path - The product path with or without a .json extension
+ * @returns Extensionless and .json product path variants
+ */
+export function getProductPathVariants(path: string): string[];
+
+/**
  * Compute the surrogate key for an authored content inserted in the pipeline.
  * @param contentBusId The content bus id of the authored content
  * @param path The path of the authored content

--- a/src/cache.js
+++ b/src/cache.js
@@ -24,6 +24,19 @@ export async function computeProductPathKey(org, site, path) {
 }
 
 /**
+ * Return the cacheable URL path variants for a Commerce product.
+ *
+ * @param {string} path - The product path with or without a .json extension
+ * @returns {string[]} Extensionless and .json product path variants
+ */
+export function getProductPathVariants(path) {
+  const extensionless = path.endsWith('.json')
+    ? path.slice(0, -'.json'.length)
+    : path;
+  return [extensionless, `${extensionless}.json`];
+}
+
+/**
  * Compute the surrogate key for an authored content inserted in the pipeline.
  * @param {string} contentBusId The content bus id of the authored content
  * @param {string} path The path of the authored content

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -13,6 +13,7 @@
 import assert from 'node:assert';
 import {
   computeProductPathKey,
+  getProductPathVariants,
   computeSiteKey,
   compute404Key,
   computePriceRulesKey,
@@ -52,6 +53,22 @@ describe('Cache Functions', () => {
       const key1 = await computeProductPathKey('adobe', 'site1', '/products/blender-pro-500');
       const key2 = await computeProductPathKey('adobe', 'site2', '/products/blender-pro-500');
       assert.notStrictEqual(key1, key2);
+    });
+  });
+
+  describe('getProductPathVariants', () => {
+    it('returns extensionless and .json variants for an extensionless path', () => {
+      assert.deepStrictEqual(
+        getProductPathVariants('/products/blender-pro-500'),
+        ['/products/blender-pro-500', '/products/blender-pro-500.json'],
+      );
+    });
+
+    it('returns extensionless and .json variants for a .json path', () => {
+      assert.deepStrictEqual(
+        getProductPathVariants('/products/blender-pro-500.json'),
+        ['/products/blender-pro-500', '/products/blender-pro-500.json'],
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Add a shared helper for the extensionless and `.json` URL variants of Commerce products so downstream purge logic can invalidate both representations.

## Validation

- `npm run lint`
- `npm test` (136 passing)

## Related Issues

None.