### PR TITLE
fix(types): sync public types (helix-commerce-api#504)

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -418,7 +418,7 @@ export interface OrderAddress {
 }
 
 /**
- * Customer contact information provided at checkout.
+ * Customer contact information and site-specific custom attributes.
  */
 export interface OrderCustomer {
   /** Customer first name. */
@@ -428,6 +428,8 @@ export interface OrderCustomer {
   email: string;
   /** Customer phone number. */
   phone?: string;
+  /** Arbitrary site-specific, customer-supplied attributes (string values, e.g. a marketing opt-in, preferred contact method, or consent timestamp). */
+  custom?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
Automated sync from helix-commerce-api PR #504:
https://github.com/adobe-rnd/helix-commerce-api/pull/504

Updates the generated TypeScript types in `src/types/public.d.ts` from the
runtime schemas in that PR.

Next steps (manual for now):
1. Merge and release this PR to publish a new `@dylandepass/helix-product-shared` version.
2. Bump that version in the source commerce-api PR so its type check passes.
3. Merge the commerce-api PR.

Opened by the **Sync public types** workflow. Closing the source PR closes this one.