### PR TITLE
fix(types): sync public types (helix-commerce-api#517)

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -29,13 +29,15 @@ export type DimensionsUnit = "cm" | "mm" | "in";
  * Aggregate customer rating for schema.org structured data.
  */
 export interface SchemaOrgAggregateRating {
-  /** Average rating value. Numeric string; converted to a number in JSON-LD. */
-  ratingValue?: string;
-  /** Total number of ratings. Numeric string; converted to an integer in JSON-LD. */
+  /** Average rating value, e.g. "4.6". Numeric string; converted to a number in JSON-LD. Should match the rating shown to users on the page. */
+  ratingValue: string;
+  /** Total number of ratings for the product. Numeric string; converted to an integer in JSON-LD. At least one of ratingCount or reviewCount is required. */
+  ratingCount?: string;
+  /** Total number of written reviews for the product (people who left a review, with or without a rating). Numeric string; converted to an integer in JSON-LD. At least one of ratingCount or reviewCount is required. */
   reviewCount?: string;
-  /** Best possible rating. Numeric string. */
+  /** Highest value allowed in the rating scale. Numeric string; defaults to 5 in JSON-LD when omitted. */
   bestRating?: string;
-  /** Worst possible rating. Numeric string. */
+  /** Lowest value allowed in the rating scale. Numeric string; defaults to 1 in JSON-LD when omitted. */
   worstRating?: string;
 }
 


### PR DESCRIPTION
Automated sync from helix-commerce-api PR #517:
https://github.com/adobe-rnd/helix-commerce-api/pull/517

Updates the generated TypeScript types in `src/types/public.d.ts` from the
runtime schemas in that PR.

Next steps (manual for now):
1. Merge and release this PR to publish a new `@dylandepass/helix-product-shared` version.
2. Bump that version in the source commerce-api PR so its type check passes.
3. Merge the commerce-api PR.

Opened by the **Sync public types** workflow. Closing the source PR closes this one.