### PR TITLE
fix(types): sync public types (helix-commerce-api#517)

### DIFF
--- a/src/types/public.d.ts
+++ b/src/types/public.d.ts
@@ -30,7 +30,7 @@ export type DimensionsUnit = "cm" | "mm" | "in";
  */
 export interface SchemaOrgAggregateRating {
   /** Average rating value, e.g. "4.6". Numeric string; converted to a number in JSON-LD. Should match the rating shown to users on the page. */
-  ratingValue: string;
+  ratingValue?: string;
   /** Total number of ratings for the product. Numeric string; converted to an integer in JSON-LD. At least one of ratingCount or reviewCount is required. */
   ratingCount?: string;
   /** Total number of written reviews for the product (people who left a review, with or without a rating). Numeric string; converted to an integer in JSON-LD. At least one of ratingCount or reviewCount is required. */


### PR DESCRIPTION
Automated sync from helix-commerce-api PR #517:
https://github.com/adobe-rnd/helix-commerce-api/pull/517

Updates the generated TypeScript types in `src/types/public.d.ts` from the
runtime schemas in that PR.

Next steps (manual for now):
1. Merge and release this PR to publish a new `@dylandepass/helix-product-shared` version.
2. Bump that version in the source commerce-api PR so its type check passes.
3. Merge the commerce-api PR.

Opened by the **Sync public types** workflow. Closing the source PR closes this one.